### PR TITLE
Update README.MD; link to previously fixed issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RPG free for Visual Studio Code
+
 Visual Studio Code extension to convert fixed format RPGLE to free format.
 
 This is based on [rpgfreeweb](https://github.com/worksofliam/rpgfreeweb).
@@ -17,11 +18,10 @@ This is based on [rpgfreeweb](https://github.com/worksofliam/rpgfreeweb).
 
 ## How to use
 
-Highlight all or part of your source code and then right-click and use the "Convert to Free Format" option from the menu.
+Highlight all or part of your source code and then right-click and use the "Convert to Free Format" option from the menu.  If no selection was made prior to running "Convert to Free Format", then the entire document will be converted _and_ the `**FREE` will be added as the first line.
 
-A couple of caveats:
-1. Your highlight should start in position 1 of the line or that line will not convert.
-2. Your highlight should end after the end of line for the last line to be converted.
+> **Note**
+> If a selection was made prior to running "Convert to Free Format", the selection will be extended to the start of the first line selected and the end of the last line selected.
 
 ## Contributors
 

--- a/src/RpgleFree.js
+++ b/src/RpgleFree.js
@@ -375,7 +375,7 @@ module.exports = class RpgleFree {
 
           case result.change:
             spaces += result.beforeSpaces;
-          // no break, need default logic too
+            // no break, need default logic too
 
           default:
             if (result.arrayoutput) {

--- a/src/specs/D.js
+++ b/src/specs/D.js
@@ -62,9 +62,9 @@ module.exports = {
 
     if ((type == ``) && output.var.standalone && (!isLikeWithAdjustedLength)) {
       if (decimals == ``)
-        output.var.type = `A`; //Character
+        output.var.type = `A`; // Character
       else
-        output.var.type = `S`; //Zoned
+        output.var.type = `S`; // Zoned
     }
     
     if (pos != ``) {


### PR DESCRIPTION
Updated the README.MD to reflect the fact that conversion of selected text will now auto-extend to convert the entire first line and last line selected.  This behavior was changed with the fix for BrianGarland/vscode-rpgfree#90.

As my prior commits for the following issues did not correctly create the link to the issues and (therfore did not) close them, I am re-listing the issues fixed on prior commits:

* Fixes BrianGarland/vscode-rpgfree#32
* Fixes BrianGarland/vscode-rpgfree#35
* Fixes BrianGarland/vscode-rpgfree#45
* Fixes BrianGarland/vscode-rpgfree#48
* Fixes BrianGarland/vscode-rpgfree#50
* Fixes BrianGarland/vscode-rpgfree#61
* Fixes BrianGarland/vscode-rpgfree#62
* Fixes BrianGarland/vscode-rpgfree#81