### PR TITLE
Additional handling of the conversion of DO/ENDDO

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-rpgfree",
 	"displayName": "RPGLE Free",
 	"description": "Visual Studio Code extension to convert fixed format RPGLE to free format",
-	"version": "0.0.27-preview+20230825.4",
+	"version": "0.0.27-preview+20230826.2",
 	"keywords": [
 		"ibmi",
 		"rpgle",

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,6 +1,6 @@
-// The module 'vscode' contains the VS Code extensibility API
+// The module `vscode` contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -12,14 +12,14 @@ const RpgleFreeX = require(`./RpgleFree`);
  */
 function RpgleFree() {
   const editor = vscode.window.activeTextEditor;
-  const eol = editor.document.eol === 1 ? '\n' : '\r\n';
+  const eol = editor.document.eol === 1 ? `\n` : `\r\n`;
 
   // Start with the indent value being a constant
   // We'll add a configuration setting for this in the future
   const indent = 2;
 
   let curRange;
-  let text = '';
+  let text = ``;
 
   // Get the selected text from the editor.
   // If nothing is selected, convert the whole document,
@@ -29,12 +29,12 @@ function RpgleFree() {
     text = editor.document.getText(curRange);
   }
 
-  if (text === '') {
+  if (text === ``) {
     curRange = new vscode.Range(
       editor.document.lineAt(0).range.start,
       editor.document.lineAt(editor.document.lineCount - 1).range.end);
-    text = '**FREE' + eol + editor.document.getText();
-  };
+    text = `**FREE${eol}${editor.document.getText()}`;
+  }
 
   // Break the soure lines into an array
   // We add an empty line at the end to flush the parsing
@@ -43,7 +43,7 @@ function RpgleFree() {
   // add an extra line, we will need to pop it off
   // before updating the document.
   let lines = text.split(eol);
-  lines.push('');
+  lines.push(``);
 
   // Convert the array of lines to free format
   let conv = new RpgleFreeX(lines, indent);
@@ -54,7 +54,7 @@ function RpgleFree() {
   // be blank.  But, before we blindly remove it
   // lets just make sure it truly is empty before
   // we pop it off.
-  if (lines.length > 0 && lines[lines.length - 1] === '') {
+  if (lines.length > 0 && lines[lines.length - 1] === ``) {
     lines.pop();
   }
 
@@ -65,24 +65,24 @@ function RpgleFree() {
   
   vscode.window.showInformationMessage(`Selected text converted to free format`);
 
-  vscode.commands.executeCommand('editor.action.formatDocument');
+  vscode.commands.executeCommand(`editor.action.formatDocument`);
   
 }
 
 export function activate(context) {
-	
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "vscode-rpgfree" is now active!');
+  
+  // Use the console to output diagnostic information (console.log) and errors (console.error)
+  // This line of code will only be executed once when your extension is activated
+  console.log(`Congratulations, your extension "vscode-rpgfree" is now active!`);
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	context.subscriptions.push(
-		vscode.commands.registerCommand(`vscode-rpgfree.rpgleFree`, function () {
-			RpgleFree();
-		})
-	);
+  // The command has been defined in the package.json file
+  // Now provide the implementation of the command with registerCommand
+  // The commandId parameter must match the command field in package.json
+  context.subscriptions.push(
+    vscode.commands.registerCommand(`vscode-rpgfree.rpgleFree`, function () {
+      RpgleFree();
+    })
+  );
 
 }
 

--- a/src/specs/D.js
+++ b/src/specs/D.js
@@ -32,9 +32,6 @@ module.exports = {
     let field = input.substr(24, 2).trim().toUpperCase();
     let keywords = input.substr(44).trimRight();
     let reservedWord = input.substr(26, 14).trim().toUpperCase();
-    let doCheck = false;
-    let doneCheck = false;
-    let tempkeywords = ``;
     let isReservedWord = (reservedWord.substr(0, 1) === `*`);
 
     // If this is a reserved word (e.g., *PROC, *STATUS), force
@@ -57,10 +54,11 @@ module.exports = {
     output.var.len = Number(len);
 
     if ((type == ``) && output.var.standalone && (!isLikeWithAdjustedLength)) {
-      if (decimals == ``)
+      if (decimals == ``) {
         output.var.type = `A`; // Character
-      else
+      } else {
         output.var.type = `S`; // Zoned
+      }
     }
     
     if (pos != ``) {
@@ -76,7 +74,7 @@ module.exports = {
       prevName = potentialName.substr(0, potentialName.length - 3);
       output.remove = true;
       if (wasSub) {
-      	output.isSub = true;
+        output.isSub = true;
       }
       output.blockType = blockType;
     }
@@ -204,6 +202,7 @@ module.exports = {
         type = `Timestamp`;
         break;
       case `*`:
+      {
         let index = keywords.toUpperCase().indexOf(`PROCPTR`);
         if ( index >= 0) {
           let removeText = keywords.substr(index, 7);
@@ -213,6 +212,7 @@ module.exports = {
           type = `Pointer`;
         }
         break;
+      }
       case ``:
         if (field == `DS` && output.var.len != 0) {
           type = `Len(` + len + `)`;
@@ -254,17 +254,21 @@ module.exports = {
       case `DS`:
       case `PR`:
       case `PI`:
-        if (field == `DS` && input.substr(23, 1).trim().toUpperCase() == `S`)
+      {
+        if (field == `DS` && input.substr(23, 1).trim().toUpperCase() == `S`) {
           keywords = `PSDS ` + keywords.trim();
+        }
 
-        if (field == `DS` && input.substr(23, 1).trim().toUpperCase() == `U`)
+        if (field == `DS` && input.substr(23, 1).trim().toUpperCase() == `U`) {
           keywords = `DtaAra(*AUTO) ` + keywords.trim();
+        }
 
         let DSisLIKEDS = (keywords.toUpperCase().indexOf(`LIKEDS`) >= 0);
         output.isLIKEDS = DSisLIKEDS;
 
-        if (name == ``) 
-          name = `*N`;
+        if (name == ``) {
+name = `*N`;
+}
 
         isSubf = (field == `DS`);
         output.isSub = (DSisLIKEDS == false);
@@ -272,17 +276,20 @@ module.exports = {
 
         output.value = `Dcl-` + field + ` ` + name + ` ` + type + ` ` + keywords.trim();
 
-	      if (DSisLIKEDS == false) {
+        if (DSisLIKEDS == false) {
           output.isSub = true;
           output.nextSpaces = indent;
         }
         output.blockType = field;
         blockType = field;
         break;
+      }
 
       case ``:
         output.isSub = (wasLIKEDS == false);
-        if (name == ``) name = `*N`;
+        if (name == ``) {
+          name = `*N`;
+        }
         if (name == `*N` && type == ``) {
           output.aboveKeywords = keywords;
           output.remove = true;


### PR DESCRIPTION
When converting a DO/ENDDO from fixed format to free format, the loop is converted to a FOR/ENDFOR loop.  Previously, it was assumed that the increment value of 1 was to be used.  This change will attempt to insert the increment value found on the matching ENDDO into the generated FOR statement.

Additionally, the fixed format DO statement supports the ommission of `factor1`, 'factor2`, and/or `result`.  The default value for `factor1` and `factor2` is 1.  If the `result` field is omitted, RPG will auto-create a temporary (internal) index variable.  In the free format, the index variable is required.  The _Convert to Free Format_ action will now auto-generate a (hopefully unique) variable name to be used in the FOR/ENDFOR loop.  **The user is required to define this variable.**

Also peformed some additional clean-up of the source code as recommended by esLint using a semistandard configuration with `curly` enabled.